### PR TITLE
Add m2e lifecycle/BuildContext support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <description>Maven plugin that automatically generates package-info.java files based on a template.</description>
     <groupId>com.github.bohnman</groupId>
     <artifactId>package-info-maven-plugin</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-m2e</version>
     <packaging>maven-plugin</packaging>
 
     <properties>
@@ -20,6 +20,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven.version>3.3.9</maven.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
+        <plexus-build-api.version>0.0.7</plexus-build-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -67,6 +68,18 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${maven-plugin-annotations.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>${plexus-build-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>
@@ -126,6 +139,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- No GPG signing
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -140,6 +154,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/src/main/java/com/github/bohnman/Package.java
+++ b/src/main/java/com/github/bohnman/Package.java
@@ -1,7 +1,5 @@
 package com.github.bohnman;
 
-import org.apache.maven.plugins.annotations.Parameter;
-
 import java.io.File;
 
 public class Package {

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Note: GPG signing disabled in pom.xml as I don't have GPG, or the keys!

Because Maven Project Builder is typically called after Java Builder,
the generated files require a further compilation phase,
which can be triggered by either having "Build Automatically" enabled
(via Eclipse "Project" menu) or by forcing a futher build
via Eclipse "Project" menu -> "Build Project".

In project pom.xml, remove any <pluginExecution> entry for
package-info-maven-plugin from <lifecycleMappingMetadata>

In project properties -> "Maven" -> "Lifecycle Mapping" you should
see "package-info:generate" with mapping "execute" and
source "maven-plugin".

Plugin's version bumped to 1.0.2-m2e