### PR TITLE
Skip generation if module has no source directory

### DIFF
--- a/src/main/java/com/github/bohnman/PackageInfoMojo.java
+++ b/src/main/java/com/github/bohnman/PackageInfoMojo.java
@@ -107,6 +107,10 @@ public class PackageInfoMojo extends AbstractMojo {
             getLog().warn("Skipping generate. No <packages/> declaration found.");
             return;
         }
+        if (!sourceDirectory.exists()) {
+            getLog().info(format("Skipping generate. No Source Directory found in this module: [%s].", sourceDirectory.getAbsolutePath()));
+            return;
+        }
 
         validate();
         loadTemplates();
@@ -122,10 +126,6 @@ public class PackageInfoMojo extends AbstractMojo {
 
         if (sourceDirectory.getAbsolutePath().equals(outputDirectory.getAbsolutePath())) {
             throw new MojoExecutionException(format("Source and Output directories cannot be the same: [%s].", sourceDirectory.getAbsolutePath()));
-        }
-
-        if (!sourceDirectory.exists()) {
-            throw new MojoExecutionException(format("Source Directory [%s] does not exist.", sourceDirectory.getAbsolutePath()));
         }
 
         if (!sourceDirectory.isDirectory()) {


### PR DESCRIPTION
Hi @bohnman !

I use this plugin to automatically create `package-info.java` files for all packages to enable the use of `@ParametersAreNonnullByDefault` annotation.

In my case the project is a multi-module maven project and some of the modules don't have a source directory. Either because they are just to nest modules or they contain only non-java files.

I added the plugin into the root pom.xml and it fails hard when it reaches a module without source directory.

The current workaround is to add a src/main/java directory structure to every single module, which I want to avoid.

This PR changes the validation and simply logs an info log to state that generation is skipped because no source dir is found.
