### PR TITLE
Allow Source and Output directory to be the same

### DIFF
--- a/src/main/java/com/github/bohnman/PackageInfoMojo.java
+++ b/src/main/java/com/github/bohnman/PackageInfoMojo.java
@@ -124,10 +124,6 @@ public class PackageInfoMojo extends AbstractMojo {
     private void validate() throws MojoExecutionException {
         getLog().debug("Validating parameters");
 
-        if (sourceDirectory.getAbsolutePath().equals(outputDirectory.getAbsolutePath())) {
-            throw new MojoExecutionException(format("Source and Output directories cannot be the same: [%s].", sourceDirectory.getAbsolutePath()));
-        }
-
         if (!sourceDirectory.isDirectory()) {
             throw new MojoExecutionException(format("Source Directory [%s] is not a directory.", sourceDirectory.getAbsolutePath()));
         }


### PR DESCRIPTION
As pointed out in issue #3 I want to be able to generate the `package-info.java` files directly into the existing source structure.

If this PR gets merged it would be nice to have a new released version of the plugin!